### PR TITLE
Correct spelling mistake

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           <p>Die Auswahl der passenden Version entscheidet &uuml;ber die Stablit&auml;t des Routers und den potentiell anfallenden Wartungsaufwand.</p>
           <p>Für das gewählte Routermodell sind folgende Versionen vorhanden:</p>
           <div class="box-inset warning-experimental initiallyhidden">
-            Vorsicht! Unsere experimentell Firmware wurde <b>nicht</b> getestet und kann dein Gerät jederzeit und unangekündigt in einen Zustand versetzen, in dem du nur mit einem Lötkolben und dem Öffnen des Gehäuses weiter kommst. Verwende diese Version nur, wenn Dir darüber im klaren bist!
+            Vorsicht! Unsere experimentell Firmware wurde <b>nicht</b> getestet und kann dein Gerät jederzeit und unangekündigt in einen Zustand versetzen, in dem du nur mit einem Lötkolben und dem Öffnen des Gehäuses weiter kommst. Verwende diese Version nur, wenn Dir darüber im Klaren bist!
             <div class="branch-experimental-dl"></div>
           </div>
           <div class="branchselect"></div>


### PR DESCRIPTION
„im Klaren... “ Klaren wird großgeschrieben. Quelle: http://www.duden.de/sprachwissen/sprachratgeber/beispiele-zur-neuen-rechtschreibung