### PR TITLE
Support different version schema

### DIFF
--- a/app.js
+++ b/app.js
@@ -220,7 +220,7 @@ var firmwarewizard = function() {
 
   function findVersion(name) {
     // version with optional date in it (e.g. 0.8.0~20160502)
-    var m = /-([0-9]+.[0-9]+.[0-9]+(~[0-9]+)?)[.-]/.exec(name);
+    var m = /-([0-9]+.[0-9]+.[0-9]+(\+[a-z0-9]+)?(~[a-z0-9]+)?)[.-]/.exec(name);
     return m ? m[1] : '';
   }
 


### PR DESCRIPTION
Support versions that include an additional alphanumeric string prefixed with a plus like the following examples.

- 2016.2.2+mwu1
- 2016.2+mwu~exp2016120501

I tested the new regex with the conventional version schema and the new one and I didn't see any problems.