### PR TITLE
Fix support for Banana Pi R1

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -41,7 +41,8 @@ var vendormodels = {
   "LeMaker": {
     "Banana Pi": "lemaker-banana-pi",
     "Banana Pro": "lemaker-banana-pro",
-    "Lamobo": "lamobo"
+    "Banana Pi R1": "lemaker-lamobo-r1"
+
   },
 
   "Linksys": {


### PR DESCRIPTION
The string was not exhaustive. Also the official name is Banana Pi BPI-R1 but I think Banana Pi R1 should be sufficient.