### PR TITLE
Added another way to write 'Ubiquiti⁣ UniFi AP Outdoor+⁣' to devices.js

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -161,7 +161,7 @@ var vendormodels = {
     "UniFi AP AC Pro": "ubiquiti-unifi-ac-pro",
     "UniFi AP AC Lite": "ubiquiti-unifi-ac-lite",
     "UniFi AP Outdoor": {"ubiquiti-unifi-outdoor": "", "ubiquiti-unifiap-outdoor": ""},
-    "UniFi AP Outdoor+": {"ubiquiti-unifi-outdoor-plus": "", "ubiquiti-unifiap-outdoor\\\+": "", "ubiquiti-unifiap-outdoor%2B": ""}
+    "UniFi AP Outdoor+": {"ubiquiti-unifi-outdoor-plus": "", "ubiquiti-unifiap-outdoor\\\+": "", "ubiquiti-unifiap-outdoor%2B": "", "ubiquiti-unifiap-outdoor%2b": ""}
   },
 
   "VoCore": {


### PR DESCRIPTION
The filename for the _Ubiquiti⁣ UniFi AP Outdoor+_ can also be encoded with a lowercase 'b'.